### PR TITLE
Fix: Read properties of undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,9 +12,11 @@ module.exports.createTranslation = function (dict, options) {
   var namespace =
     (options && options.namespace) || hash(dict, { algorithm: "md5", encoding: "base64", excludeValues: false });
   var translations = utils.convertToLanguageFirst(dict);
-  Object.keys(translations).forEach(function (lng) {
-    i18n.addResourceBundle(lng, namespace, translations[lng]);
-  });
+  if (typeof i18n !== 'undefined') {
+    Object.keys(translations).forEach(function (lng) {
+      i18n.addResourceBundle(lng, namespace, translations[lng]);
+    });
+  }
   return {
     namespace,
     translations,


### PR DESCRIPTION
Apparently `i18next` has the init option of `initImmediate: true` to initialize instantly, which is done automatically on normal react-apps and fixes the issue on next projects. While building the next project though, there is still this issue, because next does not preserve the state of the `globalI18n` while collecting the page size data. Adding this `undefined` check resolves this issue as well.